### PR TITLE
Adding bearer token header to the SSE Web API call

### DIFF
--- a/src/sse-web-api-client.js
+++ b/src/sse-web-api-client.js
@@ -1,4 +1,5 @@
 require('../config/config.js');
+require('dotenv').config();
 
 function createSSEResource(author, contents, messageId) {
     return new Promise(function(resolve, reject) {
@@ -9,7 +10,10 @@ function createSSEResource(author, contents, messageId) {
                 contents: contents,
                 messageId: messageId
             }),
-            headers: { "Content-Type": "application/json" }
+            headers: { 
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${process.env.SSE_API_KEY}`
+            }
         })
         .then(res => res.json())
         .then(function(data) {


### PR DESCRIPTION
Related to https://github.com/msoe-sse/sse-web-api/pull/15. I added the authorization header to the SSE Web API call so the historian can make authenticated requests to the SSE Web API.